### PR TITLE
New Playground

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const { graphql } = require('graphql');
 const schema = require('./schema.js');
 const express = require('express');
 const graphqlHTTP = require('./express-graphql/dist/index');
+const graphqlPlayground = require(`graphql-playground/middleware`);
 
 const ParkingspaceLoader = require('./Parkingspace/ParkingspaceLoader');
 const FlinksterLoader = require('./Flinkster/FlinksterLoader');
@@ -124,6 +125,7 @@ app.use('/graphql', graphqlHTTP({
   rootValue: root,
   graphiql: true
 }));
+app.use('/playground', graphqlPlayground.express({ endpoint: '/graphql' }))
 // set the port of our application
 // process.env.PORT lets the port be set by Heroku
 const port = process.env.PORT || 8080;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "express-graphql": "^0.6.6",
     "graphiql": "^0.11.2",
     "graphql": "^0.10.3",
+    "graphql-playground": "^1.0.33",
     "install": "^0.10.1",
     "moment": "^2.18.1",
     "moment-timezone": "^0.5.13",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "express-graphql": "^0.6.6",
     "graphiql": "^0.11.2",
     "graphql": "^0.10.3",
-    "graphql-playground": "^1.0.33",
+    "graphql-playground": "^1.1.1",
     "install": "^0.10.1",
     "moment": "^2.18.1",
     "moment-timezone": "^0.5.13",


### PR DESCRIPTION
Uses [graphQL-playground](https://github.com/graphcool/graphql-playground) as a fallback or replacement for graphiql